### PR TITLE
let the caller decide when to start taking snapshots

### DIFF
--- a/level-snapshot.js
+++ b/level-snapshot.js
@@ -58,7 +58,6 @@ var LevelSnapshot = module.exports = function (db, opts) {
   this.setupEvents()
 
   this.attach()
-  this.snapshot()
 
   return this
 }
@@ -168,7 +167,7 @@ LevelSnapshot.prototype.attach = function () {
   this.db.del = del.bind(null, this.db)
 }
 
-LevelSnapshot.prototype.snapshot = function () {
+LevelSnapshot.prototype.start = function () {
   var self = this
 
   function expireSnapshots (callback) {


### PR DESCRIPTION
It's better if `.snapshot()` is not called in the constructor since it enables the caller to decide that when the caller is ready. There might be other things that needs to be setup first.

Also renamed method to `.start()` just to get rid of things like `this.snapshot.snapshot()`.
