### PR TITLE
Flushed files

### DIFF
--- a/level-snapshot.js
+++ b/level-snapshot.js
@@ -386,10 +386,13 @@ LevelSnapshot.prototype.createSnapshotServer = function () {
       if (m.status === 0) {
         checkSnapshotSync(m.time || 0, function (err, doSync) {
           if (err) {
-            return console.error('failed to to check snapshot sync')
+            return console.error('checkSnapshotSync() failed', err)
           }
           if (doSync) {
-            syncSnapshot(streamServer, doSync, function () {
+            syncSnapshot(streamServer, doSync, function (err) {
+              if (err) {
+                return console.error('syncSnapshot() failed', err)
+              }
               syncLogs(streamServer)
             })
           } else {
@@ -406,7 +409,10 @@ LevelSnapshot.prototype.createSnapshotClient = function (port, host) {
 
   var socket = net.connect(port, host || 'localhost')
 
-  self.db.close()
+  debugc('closing db')
+  self.db.close(function () {
+    debugc('db closed')
+  })
 
   var lastSnapshotSync = this.getLastSnapshotSyncTime()
 

--- a/level-snapshot.js
+++ b/level-snapshot.js
@@ -256,6 +256,8 @@ LevelSnapshot.prototype.createSnapshotServer = function () {
       if (err) return callback(err)
       debugs('snapshots: %j', files)
 
+      streamServer.fileCount({ count: files.length })
+
       async.eachSeries(files, function (file, cb) {
         debugs('sending file: %s', file)
 
@@ -285,13 +287,7 @@ LevelSnapshot.prototype.createSnapshotServer = function () {
 
             cb()
           })
-      }, function (err) {
-        if (err) return callback(err)
-        streamServer.status({
-          status: 7 // tell the client we are done sending files
-        })
-        callback()
-      })
+      }, callback)
     })
   }
 
@@ -430,25 +426,23 @@ LevelSnapshot.prototype.createSnapshotClient = function (port, host) {
     time: lastSnapshotSync
   })
 
-  streamClient.on('status', function (m) {
-    // Status 1 -- Start Sync
+  var filesFlushed
 
-    if (m.status === 7) {
-      // Snapshot Sync is Finished
-      // Listen for Logs
-
+  streamClient.on('fileCount', function (m) {
+    // We can open the db after all files have been flushed
+    filesFlushed = after(m.count, function () {
       self.setLastSnapshotSyncTime(String(new Date().getTime()))
-
       self.db.open(function (err) {
         if (err) {
           throw err
         }
-
+        self.emit('snapshot:db-reopened')
+        debugc('db reopened successfully')
         streamClient.status({
           status: 8
         })
       })
-    }
+    })
   })
 
   streamClient.on('file', function (m) {
@@ -460,7 +454,9 @@ LevelSnapshot.prototype.createSnapshotClient = function (port, host) {
 
     if (m.ended === true) {
       debugc('file written: %s', m.filename)
-      files[m.filename].end()
+      var file = files[m.filename]
+      file.on('finish', filesFlushed)
+      file.end()
       return
     }
 

--- a/schema.proto
+++ b/schema.proto
@@ -4,6 +4,10 @@ message File {
   required bool ended = 3;
 }
 
+message FileCount {
+  required int32 count = 1;
+}
+
 message Log {
   required bytes type = 1;
   required bytes key = 2;


### PR DESCRIPTION
Apparently leveldb complains on some files, I suspect that this is because the file hasn't been flushed completely to disk.

Instead of the server telling the client when it's done sending, it lets the client know (new protobuf message) how many files it intends to send. This way we can prepare and attach 'finish' event listeners to know when all files have been flushed to disk and it should then be safe to re-open the db.
