### PR TITLE
Sync latest changes

### DIFF
--- a/level-snapshot.js
+++ b/level-snapshot.js
@@ -134,9 +134,7 @@ LevelSnapshot.prototype.attach = function () {
       callback = options
       options = {}
     }
-
-    self._logStream.write(new Buffer(JSON.stringify({type: 'put', key: key, value: value, options: options})) + '\n')
-
+    write({ type: 'put', key: key, value: value, options: options })
     self.db._snapshot.put.call(db, key, value, options, callback)
   }
 
@@ -145,18 +143,22 @@ LevelSnapshot.prototype.attach = function () {
       callback = options
       options = {}
     }
-
-    self._logStream.write(new Buffer(JSON.stringify({type: 'del', key: key, options: options})) + '\n')
-
+    write({ type: 'del', key: key, options: options })
     self.db._snapshot.del.call(db, key, options, callback)
   }
 
+  function write (data) {
+    self._logStream.write(JSON.stringify(data) + '\n')
+  }
+
+  // TODO batch!
   this.db._snapshot = {
     put: this.db.put.bind(this.db),
     del: this.db.del.bind(this.db),
     createLogStream: createLogStream.bind(this)
   }
 
+  // TODO batch!
   this.db.put = put.bind(null, this.db)
   this.db.del = del.bind(null, this.db)
 }

--- a/level-snapshot.js
+++ b/level-snapshot.js
@@ -62,10 +62,7 @@ var LevelSnapshot = module.exports = function (db, opts) {
   mkdirp.sync(this.opts.path)
   mkdirp.sync(this.opts.logPath)
 
-  // TODO remove - this is not needed for level-snapshot functionality
-  this.setupMethods()
   this.setupEvents()
-
   this.attach()
 
   return this
@@ -86,22 +83,6 @@ LevelSnapshot.prototype.setupEvents = function () {
       if (err) console.log('failed to remove', fileName)
     })
   })
-}
-
-// TODO remove - this is not needed for level-snapshot functionality
-LevelSnapshot.prototype.setupMethods = function () {
-  var self = this
-
-  this.db.methods = this.db.methods || {}
-  if (typeof this.db.methods.liveBackup !== 'undefined') return
-
-  this.db.methods.liveBackup = { type: 'async' }
-  this.db.liveBackup = function (dir, cb) {
-    if (typeof dir === 'number') {
-      dir = String(dir)
-    }
-    self.db.db.liveBackup(dir, cb)
-  }
 }
 
 LevelSnapshot.prototype.roll = function (snapshotName) {

--- a/level-snapshot.js
+++ b/level-snapshot.js
@@ -104,14 +104,6 @@ LevelSnapshot.prototype.roll = function (snapshotName) {
 LevelSnapshot.prototype.attach = function () {
   var self = this
 
-  // TODO remove - not used
-  function createLogStream () {
-    var readStream = through2()
-    fs.createReadStream(this._logStreamCurrentFile).pipe(readStream, {end: false})
-    self._logStream.pipe(readStream, {end: false})
-    return readStream
-  }
-
   function put (db, key, value, options, callback) {
     if (typeof options === 'function') {
       callback = options
@@ -137,8 +129,7 @@ LevelSnapshot.prototype.attach = function () {
   // TODO batch!
   this.db._snapshot = {
     put: this.db.put.bind(this.db),
-    del: this.db.del.bind(this.db),
-    createLogStream: createLogStream.bind(this)
+    del: this.db.del.bind(this.db)
   }
 
   // TODO batch!

--- a/level-snapshot.js
+++ b/level-snapshot.js
@@ -72,7 +72,7 @@ function setupEvents () {
   var self = this
   this.on('snapshot:start', function (name) {
     debug('taking snapshot %s', name)
-    roll.call(self, snapshotName)
+    roll.call(self, name)
   })
   this.on('snapshot:complete', function (name) {
     debug('snapshot %s completed successfully', name)

--- a/level-snapshot.js
+++ b/level-snapshot.js
@@ -70,14 +70,18 @@ util.inherits(LevelSnapshot, events.EventEmitter)
 
 LevelSnapshot.prototype.setupEvents = function () {
   var self = this
-  this.on('snapshot:start', function (snapshotName) {
+  this.on('snapshot:start', function (name) {
+    debug('taking snapshot %s', name)
     self.roll(snapshotName)
   })
-  this.on('snapshot:error', function (err) {
-    console.log('snapshot:error', err)
+  this.on('snapshot:complete', function (name) {
+    debug('snapshot %s completed successfully', name)
   })
-  this.on('snapshot:cleanup', function (snapshotName) {
-    var fileName = path.join(self.opts.logPath, snapshotName)
+  this.on('snapshot:error', function (err) {
+    console.error('failed taking snapshot', err)
+  })
+  this.on('snapshot:cleanup', function (name) {
+    var fileName = path.join(self.opts.logPath, name)
     fs.unlink(fileName, function (err) {
       if (err) console.log('failed to remove', fileName)
     })

--- a/level-snapshot.js
+++ b/level-snapshot.js
@@ -395,7 +395,7 @@ LevelSnapshot.prototype.createClient = function (port, host) {
       var ts = m.timestamp || timestamp()
       filesFlushed = after(m.count, function () {
         files = {}
-        self.setLastSnapshotSyncTime(ts)
+        setLastSnapshotSyncTime.call(self, ts)
         self.db.open(function (err) {
           if (err) throw err
           debugc('db reopened successfully')
@@ -437,6 +437,6 @@ LevelSnapshot.prototype.getLastSnapshotSyncTime = function () {
   return 0
 }
 
-LevelSnapshot.prototype.setLastSnapshotSyncTime = function (time) {
+function setLastSnapshotSyncTime (time) {
   fs.writeFileSync(this.opts.lastSyncPath, time, 'utf8')
 }

--- a/level-snapshot.js
+++ b/level-snapshot.js
@@ -113,25 +113,25 @@ LevelSnapshot.prototype.attach = function () {
     batch: this.db.batch.bind(this.db)
   }
 
-  function put (db, key, value, options, callback) {
+  this.db.put = function (key, value, options, callback) {
     if (typeof options === 'function') {
       callback = options
       options = {}
     }
     write({ type: 'put', key: key, value: value, options: options })
-    self.db._snapshot.put.call(db, key, value, options, callback)
+    self.db._snapshot.put(key, value, options, callback)
   }
 
-  function del (db, key, options, callback) {
+  this.db.del = function (key, options, callback) {
     if (typeof options === 'function') {
       callback = options
       options = {}
     }
     write({ type: 'del', key: key, options: options })
-    self.db._snapshot.del.call(db, key, options, callback)
+    self.db._snapshot.del(key, options, callback)
   }
 
-  function batch (db, ops, options, callback) {
+  this.db.batch = function (ops, options, callback) {
     if (typeof options === 'function') {
       callback = options
       options = {}
@@ -140,16 +140,12 @@ LevelSnapshot.prototype.attach = function () {
       op.options = op.options || options
       write(op)
     })
-    self.db._snapshot.batch.call(db, ops, options, callback)
+    self.db._snapshot.batch(ops, options, callback)
   }
 
   function write (data) {
     self._logStream.write(JSON.stringify(data) + '\n')
   }
-
-  this.db.put = put.bind(null, this.db)
-  this.db.del = del.bind(null, this.db)
-  this.db.batch = batch.bind(null, this.db)
 }
 
 LevelSnapshot.prototype.start = function () {

--- a/level-snapshot.js
+++ b/level-snapshot.js
@@ -252,10 +252,10 @@ LevelSnapshot.prototype.stop = function () {
   this._snapshotInterval = null
 }
 
-LevelSnapshot.prototype.createSnapshotServer = function () {
-  var self = this
+LevelSnapshot.prototype.createServer = function () {
+  debugs('createServer')
 
-  debugs('createSnapshotServer')
+  var self = this
 
   function syncSnapshot (streamServer, folder, callback) {
     debugs('syncSnapshot: %s', folder)
@@ -367,7 +367,9 @@ LevelSnapshot.prototype.createSnapshotServer = function () {
   })
 }
 
-LevelSnapshot.prototype.createSnapshotClient = function (port, host) {
+LevelSnapshot.prototype.createClient = function (port, host) {
+  debugc('createClient')
+
   var self = this
   var socket = net.connect(port, host || 'localhost')
   var lastSnapshotSync = this.getLastSnapshotSyncTime()

--- a/level-snapshot.js
+++ b/level-snapshot.js
@@ -61,14 +61,14 @@ var LevelSnapshot = module.exports = function (db, opts) {
   mkdirp.sync(this.opts.path)
   mkdirp.sync(this.opts.logPath)
 
-  this.setupEvents()
+  setupEvents.call(this)
   wrapDb.call(this)
 
   return this
 }
 util.inherits(LevelSnapshot, events.EventEmitter)
 
-LevelSnapshot.prototype.setupEvents = function () {
+function setupEvents () {
   var self = this
   this.on('snapshot:start', function (name) {
     debug('taking snapshot %s', name)

--- a/level-snapshot.js
+++ b/level-snapshot.js
@@ -72,7 +72,7 @@ function setupEvents () {
   var self = this
   this.on('snapshot:start', function (name) {
     debug('taking snapshot %s', name)
-    self.roll(snapshotName)
+    roll.call(self, snapshotName)
   })
   this.on('snapshot:complete', function (name) {
     debug('snapshot %s completed successfully', name)
@@ -88,7 +88,8 @@ function setupEvents () {
   })
 }
 
-LevelSnapshot.prototype.roll = function (snapshotName) {
+function roll (snapshotName) {
+  debug('rolling logs to %s', snapshotName)
   var filePath = path.join(this.opts.logPath, snapshotName)
 
   this._logStream.unpipe(this._logStreamNull)

--- a/level-snapshot.js
+++ b/level-snapshot.js
@@ -62,7 +62,7 @@ var LevelSnapshot = module.exports = function (db, opts) {
   mkdirp.sync(this.opts.logPath)
 
   this.setupEvents()
-  this.attach()
+  wrapDb.call(this)
 
   return this
 }
@@ -104,7 +104,7 @@ LevelSnapshot.prototype.roll = function (snapshotName) {
   }
 }
 
-LevelSnapshot.prototype.attach = function () {
+function wrapDb () {
   var self = this
 
   this.db._snapshot = {

--- a/level-snapshot.js
+++ b/level-snapshot.js
@@ -40,8 +40,7 @@ var LevelSnapshot = module.exports = function (db, opts) {
     path: './snapshots',
     logPath: './logs',
     interval: 3600,
-    lastSyncPath: './lastsync',
-    noSnapshot: false
+    lastSyncPath: './lastsync'
   }, opts)
 
   this.db = db
@@ -138,10 +137,6 @@ LevelSnapshot.prototype.attach = function () {
 }
 
 LevelSnapshot.prototype.start = function () {
-  if (this._snapshotInterval !== null) {
-    return debug('snapshots already started')
-  }
-
   var self = this
 
   function expireSnapshots (callback) {
@@ -210,12 +205,16 @@ LevelSnapshot.prototype.start = function () {
     })
   }
 
-  var interval = (parseInt(self.opts.interval, 10) || 3600) * 1000
-  this._snapshotInterval = setInterval(doSnapshot, interval)
-
-  if (this.opts.noSnapshot === false) {
-    setTimeout(doSnapshot, 500)
+  if (this._snapshotInterval === null) {
+    var interval = (parseInt(self.opts.interval, 10) || 3600) * 1000
+    debug('starting snapshots at interval %d', interval)
+    this._snapshotInterval = setInterval(doSnapshot, interval)
+  } else {
+    debug('snapshots already started')
   }
+
+  debug('triggering doSnapshot() on next tick')
+  process.nextTick(doSnapshot)
 }
 
 LevelSnapshot.prototype.stop = function () {

--- a/package.json
+++ b/package.json
@@ -15,8 +15,11 @@
     "debug": "^2.2.0",
     "mkdirp": "^0.5.1",
     "monotonic-timestamp": "0.0.9",
+    "multistream": "^2.0.2",
     "protocol-buffers-stream": "^1.3.0",
+    "pumpify": "^1.3.3",
     "rimraf": "^2.4.3",
+    "split": "^1.0.0",
     "through2": "^2.0.0",
     "xtend": "^4.0.0"
   },

--- a/schema.proto
+++ b/schema.proto
@@ -6,6 +6,7 @@ message File {
 
 message FileCount {
   required int32 count = 1;
+  required string timestamp = 2;
 }
 
 message Log {

--- a/schema.proto
+++ b/schema.proto
@@ -1,7 +1,7 @@
 message File {
   required string filename = 1;
-  required bytes contents = 2;
-  required bool ended = 3;
+  optional bytes contents = 2;
+  optional bool ended = 3;
 }
 
 message FileCount {


### PR DESCRIPTION
In this rewrite the client always fetches the latest snapshot from the server and saves that timestamp. If the client later comes back to sync after that, it only streams the latest logs from that timestamp and forward in time.
